### PR TITLE
Update pull pattern syntax and add remote-pull test with new pattern

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [ master ]
 
+# Workaround for clojure action
+env:
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -21,18 +25,12 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    - uses: DeLaGuardo/setup-graalvm@2.0
+    - uses: DeLaGuardo/setup-clojure@3.5
       with:
-        graalvm-version: '19.3.1.java11'
-    - uses: DeLaGuardo/setup-clojure@2.0
-      with:
-        tools-deps: '1.10.1.469'
+        tools-deps: '1.10.3.981'
     - uses: actions/cache@v2
       with:
-        path: |
-          .cpcache/
-          ~/.m2
-          ~/.gitlabs
+        path: ~/.m2
         key: default-build
-    - run: clojure -A:dev:test
+    - run: clojure -T:build ci
     - uses: codecov/codecov-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
-.nrepl-*
 .cpcache/
+.nrepl-*
+target/
+.rebel*
+.clj-kondo/
+.lsp/
+.calva/

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,26 @@
+(ns build
+  "Build script for this project"
+  (:require [clojure.tools.build.api :as b]
+            [org.corfield.build :as cb]))
+
+(def lib 'robertluo/remote-pull)
+(def version (format "0.1.%s" (b/git-count-revs nil)))
+(def url "https://github.com/robertluo/remote-pull")
+
+(defn tests
+  [opts]
+  (cb/run-tests opts))
+
+(defn ci
+  [opts]
+  (-> opts
+      (assoc :lib lib :version version)
+      (cb/clean)
+      (cb/run-tests)
+      (cb/jar)))
+
+(defn deploy
+  [opts]
+  (-> opts
+      (assoc :lib lib :version version)
+      (cb/deploy)))

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
-{:deps
+{:paths ["src"]
+ :deps
  {robertluo/pullable
   {:git/url "https://github.com/robertluo/pullable.git"
    :tag     "v0.3.114"
@@ -12,4 +13,8 @@
   {:extra-deps
    {lambdaisland/kaocha           {:mvn/version "1.0.632"}
     lambdaisland/kaocha-cloverage {:mvn/version "1.0-45"}}
-   :main-opts ["-m" "kaocha.runner"]}}}
+   :main-opts ["-m" "kaocha.runner"]}
+  :build
+  {:deps       {io.github.seancorfield/build-clj
+                {:git/tag "v0.6.7" :git/sha "22c2d09"}}
+   :ns-default build}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,15 +1,15 @@
-{:deps      
+{:deps
  {robertluo/pullable
   {:git/url "https://github.com/robertluo/pullable.git"
-   :tag     "v0.1.2"
-   :sha     "ccb0bb4a82e539f50f1e783852d99ca36ff1a0e5"}
-  byte-streams              {:mvn/version "0.2.4"}
-  com.cognitect/transit-clj {:mvn/version "1.0.324"}}
- :aliases   
+   :tag     "v0.3.114"
+   :sha     "cf199e9cfff2df478c4e36c805b0db5261719f46"}
+  org.clj-commons/byte-streams {:mvn/version "0.2.10"}
+  com.cognitect/transit-clj    {:mvn/version "1.0.324"}}
+ :aliases
  {:dev
   {:extra-paths ["test"]}
   :test
-  {:extra-deps 
+  {:extra-deps
    {lambdaisland/kaocha           {:mvn/version "1.0.632"}
     lambdaisland/kaocha-cloverage {:mvn/version "1.0-45"}}
-   :main-opts  ["-m" "kaocha.runner"]}}}
+   :main-opts ["-m" "kaocha.runner"]}}}

--- a/src/robertluo/remote_pull.clj
+++ b/src/robertluo/remote_pull.clj
@@ -8,8 +8,8 @@
     1. pull on the model-maker
     1. encode/decode format
     1. handle with exception
-   
-   model-maker is a function takes ring request as its argument, 
+
+   model-maker is a function takes ring request as its argument,
    returns a map as pullable model."
   [model-maker]
   (-> model-maker

--- a/src/robertluo/remote_pull/format.clj
+++ b/src/robertluo/remote_pull/format.clj
@@ -1,6 +1,6 @@
 (ns robertluo.remote-pull.format
   (:require
-   [robertluo.pullable :refer [pull]]
+   [robertluo.pullable :as pull]
    [clojure.edn :as edn]
    [byte-streams :as bs]
    [cognitect.transit :as transit]))
@@ -39,7 +39,7 @@
     (if-let [pattern (pattern-extractor req)]
       (let [model (model-maker req)]
         {:status 200
-         :body   (pull model pattern)})
+         :body   (pull/run pattern model)})
       (throw (ex-info "No pattern" {:req req})))))
 
 (defn with-exception

--- a/test/robertluo/remote_pull/format_test.clj
+++ b/test/robertluo/remote_pull/format_test.clj
@@ -18,8 +18,8 @@
 (deftest with-pull
   (let [handler (sut/with-pull (constantly {:foo "bar"}) :body-params)]
     (testing "pull with pattern returns result"
-      (is (= {:status 200 :body {:foo "bar"}}
-             (handler {:body-params :foo}))))
+      (is (= {:status 200 :body [{:foo "bar"} {'?foo "bar"}]}
+             (handler {:body-params '{:foo ?foo}}))))
     (testing "if no pattern, throw exception"
       (is (thrown? clojure.lang.ExceptionInfo (handler {}))))))
 
@@ -38,7 +38,7 @@
   (testing "when remote returns 200, return its body decoded"
     (is (= :ok
            (sut/remote-pull (constantly {:status 200 :body ":ok"})
-                            {:foo "bar"} "application/edn"))))
+                            '{:foo "bar"} "application/edn"))))
   (testing "when remote returns status other than 200, raises exception"
     (is (thrown? clojure.lang.ExceptionInfo
                  (sut/remote-pull (constantly {:status 400 :body ":ok"})

--- a/test/robertluo/remote_pull_test.clj
+++ b/test/robertluo/remote_pull_test.clj
@@ -1,11 +1,18 @@
 (ns robertluo.remote-pull-test
   (:require
    [robertluo.remote-pull :as sut]
-   [clojure.test :refer [deftest is]]))
+   [clojure.test :refer [deftest testing is]]))
 
 (deftest model->handler
   (let [handler (sut/model->handler (constantly {:foo "bar"}))]
-    (is (= {:status 200}
-           (-> (handler {:headers {"content-type" "application/edn"}
-                         :body ":foo"})
-               (select-keys [:status]))))))
+    (testing "Returns the handler from the model."
+      (is (= {:status 200}
+             (-> (handler {:headers {"content-type" "application/edn"}
+                           :body    (str '{:foo ?})})
+                 (select-keys [:status])))))))
+
+(deftest remote-pull
+  (testing "when remote returns 200, return its body decoded"
+    (let [handler (sut/model->handler (constantly  {:a 2}))]
+      (is (= [{:a 2} {'?a 2}]
+             (sut/remote-pull handler '{:a ?a} "application/edn"))))))


### PR DESCRIPTION
Closes #4 

- Update pull pattern syntax in src and test
- Add a `remote-pull` test using the latest pull pattern syntax as an example
- Add build ns for build-clj tasks
- Update workflow to use `clj -T:build ci`