### PR TITLE
Add sse formatter and handler

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,9 @@
  :deps
  {robertluo/pullable           {:mvn/version "0.3.114"}
   org.clj-commons/byte-streams {:mvn/version "0.2.10"}
-  com.cognitect/transit-clj    {:mvn/version "1.0.324"}}
+  com.cognitect/transit-clj    {:mvn/version "1.0.324"}
+  manifold/manifold            {:mvn/version "0.2.3"}
+  org.clojure/core.async       {:mvn/version "1.5.648"}}
  :aliases
  {:dev
   {:extra-paths ["test"]}

--- a/src/robertluo/remote_pull.clj
+++ b/src/robertluo/remote_pull.clj
@@ -1,7 +1,8 @@
 (ns robertluo.remote-pull
   "Remotely pull server and client"
   (:require
-   [robertluo.remote-pull.format :as impl]))
+   [robertluo.remote-pull.format :as impl]
+   [clojure.core.async :as async]))
 
 (defn model->handler
   "Returns a ring handler that will:
@@ -16,6 +17,14 @@
       (impl/with-pull :body-params)
       impl/with-format
       impl/with-exception))
+
+(defn model->sse-handler
+  [model-maker]
+  (let [ch-out (async/chan)]
+    (-> model-maker
+        (impl/with-pull-sse :body-params ch-out)
+        (impl/with-format-sse ch-out)
+        impl/with-exception)))
 
 (defn remote-pull
   "Pull the requested data from a server using:

--- a/test/robertluo/remote_pull_test.clj
+++ b/test/robertluo/remote_pull_test.clj
@@ -1,7 +1,8 @@
 (ns robertluo.remote-pull-test
   (:require
    [robertluo.remote-pull :as sut]
-   [clojure.test :refer [deftest testing is]]))
+   [clojure.test :refer [deftest testing is]]
+   [manifold.stream :as s]))
 
 (deftest model->handler
   (let [handler (sut/model->handler (constantly {:foo "bar"}))]
@@ -16,3 +17,16 @@
     (let [handler (sut/model->handler (constantly  {:a 2}))]
       (is (= {'?a 2}
              (sut/remote-pull handler '{:a ?a} :var-only "application/edn"))))))
+
+(deftest remote-pull-sse
+  (testing "when remote returns 200, return its body as a stream"
+    (let [a-data   (atom {:a 1})
+          handler  (sut/model->sse-handler (constantly a-data))
+          response (sut/remote-pull handler '{:a ?a} :var-only "text/event-stream")]
+      (is (= {'?a 1}
+             @(s/take! response)))
+      (reset! a-data {:a 2})
+      (is (= {'?a 2}
+             @(s/take! response)))
+      (reset! a-data nil)
+      (is (= :no-value @(s/take! response :no-value))))))


### PR DESCRIPTION
CLoses #8 

- The model is an `atom`.
- In the see handler, we `add-watch` this atom and when it changes we `async/put!` the new value to an `async/chan`
- Add a `Formatter` for the content-type `text/event-stream`